### PR TITLE
Feature/general context

### DIFF
--- a/Microchip/PIC32MM/XC32/os_cpu_a.S
+++ b/Microchip/PIC32MM/XC32/os_cpu_a.S
@@ -47,7 +47,7 @@
     .global  OSIntCtxSw
     .global  OSCtxSw
     .global  CoreTimerIntHandler
-    .global  _general_exception_handler
+    .global  _general_exception_context
 
 
 /*
@@ -352,8 +352,8 @@ TICK_INC_NESTING:
 *
 *********************************************************************************************************
 */    
-    .ent _general_exception_handler
-_general_exception_handler:
+    .ent _general_exception_context
+_general_exception_context:
     OS_CPU_REGS_SAVE	EXCEPTION_CAUSE
 
     ori   $8,  $0,  0x007C                     /* Switch context only if a syscall exception occurred  */
@@ -379,4 +379,4 @@ RESTORE_CTX:
     OS_CPU_REGS_RESTORE
 
     eret                                       /* Resume execution in new task			       */
-    .end _general_exception_handler
+    .end _general_exception_context

--- a/Microchip/PIC32MM/XC32/os_cpu_a.inc
+++ b/Microchip/PIC32MM/XC32/os_cpu_a.inc
@@ -199,13 +199,6 @@
     la    $10, OSTCBCurPtr                     /* Save the current task's stack pointer                */
     lw    $11, 0($10)
     sw    $29, 0($11)
-    
-    la    $8,  OSTCBHighRdyPtr                 /* Update the current TCB                               */
-    lw    $9,  0($8)
-    la    $10, OSTCBCurPtr
-    sw    $9,  0($10)
-
-    lw    $29, 0($9)                           /* Load the new task's stack pointer                    */
 
 1:
     la    $8,  OSIntEnter                      /* Call OSIntEnter() for ENTER ISR OS Notification      */

--- a/Microchip/PIC32MM/XC32/os_cpu_a.inc
+++ b/Microchip/PIC32MM/XC32/os_cpu_a.inc
@@ -199,6 +199,13 @@
     la    $10, OSTCBCurPtr                     /* Save the current task's stack pointer                */
     lw    $11, 0($10)
     sw    $29, 0($11)
+    
+    la    $8,  OSTCBHighRdyPtr                 /* Update the current TCB                               */
+    lw    $9,  0($8)
+    la    $10, OSTCBCurPtr
+    sw    $9,  0($10)
+
+    lw    $29, 0($9)                           /* Load the new task's stack pointer                    */
 
 1:
     la    $8,  OSIntEnter                      /* Call OSIntEnter() for ENTER ISR OS Notification      */


### PR DESCRIPTION
_general_exception_handler changed to _general_exception_context for avoiding of double saving CPU registers.